### PR TITLE
fix: inconsistent parish metadata fields (#5), scraping blank pages  

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    // disable strict type checking
+    // bc scrapy has no inline nor type stubs, this is easier
+    "python.analysis.typeCheckingMode": "standard",
+}


### PR DESCRIPTION
### Description

This pr addresses two issues:

1. The issue described in #5 was fixed. See 161f580e4df3be985b2a19314da73dda96a8db9d
2. Another bug was fixed, that was previously not assigned to any issue. Some pages of parishes are almost blank. Mostly to provide an external linke to a third party service with the sources. Before, these pages were ignored. Now these urls set there are just scraped and included in the output with `{ "external_url": "https://some.url" }`  See 161f580e4df3be985b2a19314da73dda96a8db9d



Closes #5