### PR TITLE
Include coordinates when fetching locations

### DIFF
--- a/matricula_online_scraper/cli/fetch.py
+++ b/matricula_online_scraper/cli/fetch.py
@@ -50,6 +50,13 @@ def location(
         Optional[Tuple[int, int]],
         typer.Option(help="Filter by date of the parish registers."),
     ] = None,
+    exclude_coordinates: Annotated[
+        bool,
+        typer.Option(
+            "--exclude-coordinates/",
+            help="Coordinates of a parish will be included by default. Using this option will exclude coordinates from the output and speed up the scraping process.",
+        ),
+    ] = False,
     log_level: LogLevelOption = DEFAULT_SCRAPER_LOG_LEVEL,
     silent: SilentOption = DEFAULT_SCRAPER_SILENT,
 ):
@@ -108,6 +115,7 @@ def location(
             diocese=diocese,
             date_filter=date_filter,
             date_range=date_range or (0, 9999),
+            include_coordinates=not exclude_coordinates,
         )
         process.start()
 

--- a/matricula_online_scraper/spiders/utils.py
+++ b/matricula_online_scraper/spiders/utils.py
@@ -1,0 +1,26 @@
+"""
+Utilities for the spiders
+"""
+
+from typing import Tuple
+import re
+
+type Coordinates = Tuple[float, float]
+"""[Longitude, Latitude]"""
+
+
+def extract_coordinates(text: str) -> Coordinates | None:
+    """Extract and parse coordinates substring from a Matricula html document."""
+    # coordinates information can be extracted from a script tag inside a Matricula HTML page
+    # example: `POINT (16.373 48.208)`
+    # this substring
+    pattern = r"POINT \((-?\d+\.\d+)\s+(-?\d+\.\d+)\)"
+    matches = re.search(pattern, text)
+    if not matches:
+        return None
+    try:
+        longitutde = float(matches.group(1))
+        latitude = float(matches.group(2))
+    except Exception as _:
+        return None
+    return (longitutde, latitude)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "matricula-online-scraper"
-version = "0.3.0"
+version = "0.4.0"
 description = "Command Line Interface tool for scraping Matricula Online https://data.matricula-online.eu."
 repository = "https://github.com/lsg551/matricula-online-scraper"
 authors = ["Luis Schulte"]


### PR DESCRIPTION
### Description

From 199239a062d18e6f2f2107bed0fb18af476a94ef:

>Coordinates of parishes are now included by default when scraping locations. The new fields `longitude` and `latitude` contain floats.
>
>Because this effectively doubles the amount of requests, be aware that the extra information comes with a price. This feature can be disabled by using the flag `--exclude-coordinates`. Use it if you suffer decreased performance.

Resolves #18