### PR TITLE
Enhance publishing workflows

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,13 +7,12 @@ on:
       - "v*.*.*"
   workflow_dispatch:
 
-permissions:
-  id-token: write # required for trusted publishing to PyPi
-  contents: read
-
 jobs:
   publish:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write # required for trusted publishing to PyPi
+      contents: read
     steps:
       - uses: actions/checkout@v4
 
@@ -32,12 +31,29 @@ jobs:
       - name: Install dependencies
         run: uv sync --all-extras --dev
 
+      - name: Validate version consistency
+        run: |
+          TAG_VERSION=${GITHUB_REF#refs/tags/v}
+          PACKAGE_VERSION=$(python -c "from importlib.metadata import version; print(version('matricula-online-scraper'))")
+          if [ "$TAG_VERSION" != "$PACKAGE_VERSION" ]; then
+            echo "Tag version ($TAG_VERSION) doesn't match package version ($PACKAGE_VERSION)"
+            exit 1
+          fi
+
       - name: Build package
-        run: uv build
+        run: uv build --out-dir dist/
+
+      - name: Archive build artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist-without-markdown
+          path: |
+            dist
+            !dist/**/*.md
 
       # added "trusted publisher" to PyPi to avoid entering credentials
       - name: Publish package to PyPi
-        run: uv publish
+        run: uv publish --token ${{ secrets.PYPI_TOKEN }}
 
       - name: Prune uv cache
         run: uv cache prune --ci

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,3 +44,5 @@ this is not enforced though. Also, always use type hints wherever possible!
 After merging a pull request into the main branch, create a new release with a
 detailed description as well as a tag. This tag ref will trigger a workflow to
 build and publish the package to PyPi.
+
+Do NOT forget to bump the verison number in the `pyproject.toml` file before!

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "matricula-online-scraper"
-version = "0.5.0"
+version = "0.5.1"
 description = "Command Line Interface tool for scraping Matricula Online https://data.matricula-online.eu."
 authors = [{ name = "Luis Schulte" }]
 license = { text = "MIT" }

--- a/uv.lock
+++ b/uv.lock
@@ -346,7 +346,7 @@ wheels = [
 
 [[package]]
 name = "matricula-online-scraper"
-version = "0.5.0"
+version = "0.5.1"
 source = { editable = "." }
 dependencies = [
     { name = "scrapy" },


### PR DESCRIPTION
> * The workflows previously failed, and I tried to fix it. However, I misspelled the arguments for the trusted publisher in PyPi, so it could not work …
> * set granted permissions to job level for better security
> * additional steps for version consistency checking between pyproject.toml and the latest git tag ref (so I do not forget to bump it there) and uploading the build artifact
> * use the existing token together with the trusted publisher (PyPi writes that this can and should be complemented